### PR TITLE
Fix workflow push permissions

### DIFF
--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -8,6 +8,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   monitor:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- allow push to repository in monitor workflow by setting contents permission

## Testing
- `python3 src/monitor.py` *(fails: ModuleNotFoundError for requests)*
- `pip install requests` *(fails: could not connect to pypi)*

------
https://chatgpt.com/codex/tasks/task_e_6877ba8291a0832884e08719c2ea392d