### PR TITLE
Fix GitHub issue creation in monitor workflow

### DIFF
--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   monitor:
@@ -29,6 +30,8 @@ jobs:
       
     - name: Run uptime check
       run: python3 src/monitor.py
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
     - name: Commit and push changes
       run: |

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ kommt.
   Python‑Skript `src/monitor.py`.
 * Der aktuelle Status wird in `status.json` gespeichert und zusätzlich in
   `history.json` archiviert.
+* Bei zweimaligem Fehlschlag versucht `monitor.py` automatisch, ein GitHub-Issue anzulegen.
+* Hierzu wird das Standard-Token `GITHUB_TOKEN` genutzt, das der Workflow mit den Rechten `contents: write` und `issues: write` bereitstellt.
 * Änderungen an diesen Dateien werden automatisch committet. Dadurch
   löst jeder Lauf eine Aktualisierung der GitHub&nbsp;Pages‑Seite aus.
 


### PR DESCRIPTION
## Summary
- allow GitHub Actions token to create issues
- pass `GITHUB_TOKEN` to the uptime monitor step
- document automatic issue creation in README

## Testing
- `pip install -r requirements.txt`
- `python3 src/monitor.py` *(fails locally: No GITHUB_TOKEN found)*

------
https://chatgpt.com/codex/tasks/task_e_6878aefe7f448328ad727b4ac4009fbf