### PR TITLE
Update monitor schedule to every 2 hours

### DIFF
--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -2,8 +2,8 @@ name: Website Uptime Monitor
 
 on:
   schedule:
-    # Runs every 15 minutes
-    - cron: '*/15 * * * *'
+    # Runs every 2 hours
+    - cron: '0 */2 * * *'
   push:
     branches: [ main ]
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ kommt.
 
 ## Funktionsweise
 
-* Alle 15 Minuten startet ein GitHub&nbsp;Actions&nbsp;Workflow das
+* Alle 2 Stunden startet ein GitHub&nbsp;Actions&nbsp;Workflow das
   Python‑Skript `src/monitor.py`.
 * Der aktuelle Status wird in `status.json` gespeichert und zusätzlich in
   `history.json` archiviert.

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
         </div>
 
         <div class="last-updated">
-            Automatisch aktualisiert alle 15 Minuten via GitHub Actions
+            Automatisch aktualisiert alle 2 Stunden via GitHub Actions
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- adjust GitHub Actions cron job to run once every 2 hours
- update README description
- update site footer text

## Testing
- `pip install requests`
- `python3 src/monitor.py`
- `python3 -m py_compile src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6878c1063ab88328afeab42b9c390c29